### PR TITLE
OS and data for unittesting 

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9"]
 
     steps:
@@ -50,7 +50,7 @@ jobs:
         
     - uses: iterative/setup-dvc@v1
     - name: Get data
-      run: dvc pull
+      run: dvc pull data/dummy
         
     - name: Run tests and collect coverage
       run: |

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9"]
 
     steps:

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9"]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9"]
 
     steps:

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -10,16 +10,14 @@ from dotenv import find_dotenv, load_dotenv
 from PIL import Image
 from torchvision import transforms
 from tqdm import tqdm
-import random
 
-@click.command()
+
+click.command()
 @click.argument("input_filepath", type=click.Path(exists=True))
 @click.argument("output_filepath", type=click.Path())
 @click.argument("image_shape", default=224, type=click.Path())
 @click.argument("norm_strat", default="model", type=click.Path())
-def main(
-    input_filepath: str, output_filepath: str, image_shape: int, norm_strat: str
-) -> None:
+def main(input_filepath: str, output_filepath: str, image_shape: int, norm_strat: str) -> None:
     """Runs data processing scripts to turn raw data from (../raw) into
     cleaned data ready to be analyzed (saved in ../processed).
     """
@@ -42,7 +40,7 @@ def main(
         # Iterate through all animals
         for c_idx, animal in enumerate(glob(input_filepath + f"/{dataset}/*")):
             print(f"animal: {animal}")
-            class_length.append(class_length[-1]+len(glob(f"{animal}/*")))
+            class_length.append(class_length[-1] + len(glob(f"{animal}/*")))
             # iterte through all animal images
             for file in tqdm(glob(f"{animal}/*")):
                 # load image and resize it to "image_shape"
@@ -86,7 +84,7 @@ def main(
         else:
             n_samples = 6
 
-        dummy_idx = [list(range(class_length[i], class_length[i]+n_samples)) for i in range(10)]
+        dummy_idx = [list(range(class_length[i], class_length[i] + n_samples)) for i in range(10)]
         dummy_idx = [j for i in dummy_idx for j in i]
         dummy_norm_images = norm_images[dummy_idx]
         dummy_torch_labels = torch_labels[dummy_idx]
@@ -95,6 +93,7 @@ def main(
             pickle.dump((norm_images, torch_labels), fp)
         with open(dummy_path + f"/{dataset}.pickle", "wb") as fp:
             pickle.dump((dummy_norm_images, dummy_torch_labels), fp)
+
 
 if __name__ == "__main__":
     log_fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -13,6 +13,8 @@ from tqdm import tqdm
 
 
 click.command()
+
+
 @click.argument("input_filepath", type=click.Path(exists=True))
 @click.argument("output_filepath", type=click.Path())
 @click.argument("image_shape", default=224, type=click.Path())

--- a/src/visualization/visualise.py
+++ b/src/visualization/visualise.py
@@ -4,9 +4,7 @@ from torchviz import make_dot
 
 
 def visualize_model():
-    model = timm.create_model(
-        "convnext_atto", pretrained=True, in_chans=3, num_classes=10
-    )
+    model = timm.create_model("convnext_atto", pretrained=True, in_chans=3, num_classes=10)
     x = torch.randn(1, 3, 224, 224)
     y = model(x)
     make_dot(y.mean(), params=dict(model.named_parameters())).view()

--- a/test_environment.py
+++ b/test_environment.py
@@ -14,9 +14,7 @@ def main():
 
     if system_major != required_major:
         raise TypeError(
-            "This project requires Python {}. Found: Python {}".format(
-                required_major, sys.version
-            )
+            "This project requires Python {}. Found: Python {}".format(required_major, sys.version)
         )
     else:
         print(">>> Development environment passes all tests!")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,12 +36,12 @@ class TestClass:
     N_val = 1000
 
     @pytest.mark.skipif(
-        not os.path.exists(os.path.join(_PATH_DATA, "processed/training_data.pickle")),
+        not os.path.exists(os.path.join(_PATH_DATA, "dummy/training_data.pickle")),
         reason="Data files not found",
     )
     def test_train_data(self):
         # load data
-        dataset = data_load(os.path.join(_PATH_DATA, "processed/training_data.pickle"))
+        dataset = data_load(os.path.join(_PATH_DATA, "dummy/training_data.pickle"))
         # Ensure correct data-size
         assert len(dataset) == self.N_train, "Data is incomplete"
         # Ensure correct data shape
@@ -61,12 +61,12 @@ class TestClass:
         ), "Labels do not represent all classes."
 
     @pytest.mark.skipif(
-        not os.path.exists(os.path.join(_PATH_DATA, "processed/testing_data.pickle")),
+        not os.path.exists(os.path.join(_PATH_DATA, "dummy/testing_data.pickle")),
         reason="Data files not found",
     )
     def test_test_data(self):
         # load data
-        dataset = data_load(os.path.join(_PATH_DATA, "processed/testing_data.pickle"))
+        dataset = data_load(os.path.join(_PATH_DATA, "dummy/testing_data.pickle"))
         # Ensure correct data-size
         assert len(dataset) == self.N_test, "Data is incomplete"
         # Ensure correct data shape
@@ -86,12 +86,12 @@ class TestClass:
         ), "Labels do not represent all classes."
 
     @pytest.mark.skipif(
-        not os.path.exists(os.path.join(_PATH_DATA, "processed/validation_data.pickle")),
+        not os.path.exists(os.path.join(_PATH_DATA, "dummy/validation_data.pickle")),
         reason="Data files not found",
     )
     def test_val_data(self):
         # load data
-        dataset = data_load(os.path.join(_PATH_DATA, "processed/validation_data.pickle"))
+        dataset = data_load(os.path.join(_PATH_DATA, "dummy/validation_data.pickle"))
         # Ensure correct data-size
         assert len(dataset) == self.N_val, "Data is incomplete"
         # Ensure correct data shape

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -86,16 +86,12 @@ class TestClass:
         ), "Labels do not represent all classes."
 
     @pytest.mark.skipif(
-        not os.path.exists(
-            os.path.join(_PATH_DATA, "processed/validation_data.pickle")
-        ),
+        not os.path.exists(os.path.join(_PATH_DATA, "processed/validation_data.pickle")),
         reason="Data files not found",
     )
     def test_val_data(self):
         # load data
-        dataset = data_load(
-            os.path.join(_PATH_DATA, "processed/validation_data.pickle")
-        )
+        dataset = data_load(os.path.join(_PATH_DATA, "processed/validation_data.pickle"))
         # Ensure correct data-size
         assert len(dataset) == self.N_val, "Data is incomplete"
         # Ensure correct data shape

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,9 +16,7 @@ class TestClass:
         with pytest.raises(ValueError, match="Expected input to a 4D tensor"):
             self.model(torch.rand(1, 224, 224)).shape == (1, 10)
 
-        with pytest.raises(
-            ValueError, match="Expected each sample to have shape {3, 224, 224}"
-        ):
+        with pytest.raises(ValueError, match="Expected each sample to have shape {3, 224, 224}"):
             self.model(torch.rand(1, 6, 224, 224)).shape == (1, 10)
             self.model(torch.rand(1, 3, 6, 224)).shape == (1, 10)
             self.model(torch.rand(1, 3, 224, 6)).shape == (1, 10)


### PR DESCRIPTION
Should only get accepted once we have configured the google cloud storage to include the data/dummy.
It contains changes wrt. pep8 compliance, unittesting is now done on windows, macos and ubuntu. And once GCS is up and running, unitests and therefore coverage will be calculated based on the dummy dataset (approx 3.8 GB).